### PR TITLE
Fix setting titleField on a listView

### DIFF
--- a/layouts.js
+++ b/layouts.js
@@ -78,7 +78,7 @@ define(function(require) {
         },
         setters: {
             titleField: function(name) {
-                this.view.opts.titleField = name;
+                this.view.options.titleField = name;
             },
             renderRow: function(func) {
                 this.view.options.renderRow = func;


### PR DESCRIPTION
Setting a title field on a listView doesn't work because it uses 'opts' instead of 'options'. This patch fixes that.
