### PR TITLE
Fix DOM Exception 12 in Chrome.

### DIFF
--- a/css-animations.js
+++ b/css-animations.js
@@ -1,4 +1,3 @@
-
 (function() {
 
     // Utility
@@ -139,7 +138,7 @@
                                         styles.cssRules.length);
         }
         catch(e) {
-            if(e.name == 'SYNTAX_ERR') {
+            if(e.name == 'SYNTAX_ERR' || e.name == 'SyntaxError') {
                 idx = styles.insertRule('@-webkit-keyframes ' + name + '{}',
                                         styles.cssRules.length);
             }


### PR DESCRIPTION
Chrome's error name is "SyntaxError" rather than "SYNTAX_ERR".
